### PR TITLE
[SITE-6015] #2 Add search_api_pantheon_cache submodule 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,18 @@
             "@code:lint"
         ]
     },
+    "autoload": {
+        "psr-4": {
+            "Drupal\\search_api_pantheon\\": "src/",
+            "Drupal\\search_api_pantheon_cache\\": "modules/search_api_pantheon_cache/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Drupal\\Tests\\search_api_pantheon\\Unit\\": "tests/src/Unit/",
+            "Drupal\\Tests\\search_api_pantheon_cache\\Unit\\": "modules/search_api_pantheon_cache/tests/src/Unit/"
+        }
+    },
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,

--- a/modules/search_api_pantheon_cache/search_api_pantheon_cache.info.yml
+++ b/modules/search_api_pantheon_cache/search_api_pantheon_cache.info.yml
@@ -1,0 +1,7 @@
+name: 'Search API Pantheon Cache'
+type: module
+description: 'Re-invalidates Solr-backed views cache after autoSoftCommit to prevent stale search results.'
+core_version_requirement: ^10 || ^11
+package: Search
+dependencies:
+  - search_api_pantheon:search_api_pantheon

--- a/modules/search_api_pantheon_cache/search_api_pantheon_cache.services.yml
+++ b/modules/search_api_pantheon_cache/search_api_pantheon_cache.services.yml
@@ -1,0 +1,7 @@
+services:
+  search_api_pantheon_cache.solr_commit_aware_cache_invalidator:
+    class: Drupal\search_api_pantheon_cache\EventSubscriber\SolrCommitAwareCacheInvalidator
+    arguments: ['@state']
+    tags:
+      - { name: cache_tags_invalidator }
+      - { name: event_subscriber }

--- a/modules/search_api_pantheon_cache/src/EventSubscriber/SolrCommitAwareCacheInvalidator.php
+++ b/modules/search_api_pantheon_cache/src/EventSubscriber/SolrCommitAwareCacheInvalidator.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\search_api_pantheon_cache\EventSubscriber;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\search_api\Event\ItemsIndexedEvent;
+use Drupal\search_api\Event\SearchApiEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Re-invalidates Search API cache tags after Solr's commit window.
+ *
+ * Solr's autoSoftCommit (5s on Pantheon) creates a race condition: Drupal
+ * invalidates cache tags at entity-save time, but Solr hasn't committed yet.
+ * A visitor in that 0-5s window caches stale Solr results. This service
+ * schedules a second invalidation after the commit window to clear stale
+ * cached pages.
+ *
+ * Enable by installing the search_api_pantheon_cache submodule:
+ * @code
+ * drush en search_api_pantheon_cache
+ * @endcode
+ */
+class SolrCommitAwareCacheInvalidator implements CacheTagsInvalidatorInterface, EventSubscriberInterface {
+
+  /**
+   * Seconds to wait after invalidation before re-invalidating.
+   *
+   * Solr autoSoftCommit is 5s on Pantheon. 1s buffer ensures Solr has
+   * committed before the re-invalidation fires.
+   */
+  const SOLR_COMMIT_BUFFER_SECONDS = 6;
+
+  const STATE_KEY = 'search_api_pantheon.reinvalidate_due';
+
+  /**
+   * Guard flag to prevent infinite recursion during re-invalidation.
+   */
+  private bool $isReInvalidating = FALSE;
+
+  public function __construct(
+    protected StateInterface $state,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidateTags(array $tags): void {
+    if ($this->isReInvalidating) {
+      return;
+    }
+    $this->scheduleReInvalidation($tags);
+  }
+
+  /**
+   * Handles the ITEMS_INDEXED event from Search API.
+   */
+  public function onItemsIndexed(ItemsIndexedEvent $event): void {
+    $index_id = $event->getIndex()->id();
+    $this->scheduleReInvalidation(["search_api_list:$index_id"]);
+  }
+
+  /**
+   * Re-invalidates search cache tags after the Solr commit window.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $pending = $this->state->get(self::STATE_KEY, []);
+    if (empty($pending)) {
+      return;
+    }
+
+    $now = time();
+    $due = array_filter($pending, fn($time) => $now >= $time);
+    if (empty($due)) {
+      return;
+    }
+
+    $remaining = array_diff_key($pending, $due);
+    empty($remaining)
+      ? $this->state->delete(self::STATE_KEY)
+      : $this->state->set(self::STATE_KEY, $remaining);
+
+    $this->isReInvalidating = TRUE;
+    $this->reInvalidateTags(array_keys($due));
+    $this->isReInvalidating = FALSE;
+  }
+
+  /**
+   * Fires cache tag invalidation for the given tags.
+   */
+  protected function reInvalidateTags(array $tags): void {
+    Cache::invalidateTags($tags);
+  }
+
+  /**
+   * Filters for search_api_list tags and schedules re-invalidation.
+   */
+  protected function scheduleReInvalidation(array $tags): void {
+    $list_tags = array_filter($tags, fn($tag) => str_starts_with($tag, 'search_api_list:'));
+    if (empty($list_tags)) {
+      return;
+    }
+
+    $pending = $this->state->get(self::STATE_KEY, []);
+    $due_at = time() + self::SOLR_COMMIT_BUFFER_SECONDS;
+    foreach ($list_tags as $tag) {
+      $pending[$tag] = $due_at;
+    }
+    $this->state->set(self::STATE_KEY, $pending);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      SearchApiEvents::ITEMS_INDEXED => 'onItemsIndexed',
+      KernelEvents::REQUEST => ['onRequest', 100],
+    ];
+  }
+
+}

--- a/modules/search_api_pantheon_cache/tests/src/Unit/SolrCommitAwareCacheInvalidatorTest.php
+++ b/modules/search_api_pantheon_cache/tests/src/Unit/SolrCommitAwareCacheInvalidatorTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\search_api_pantheon_cache\Unit;
+
+use Drupal\Core\State\StateInterface;
+use Drupal\search_api\Event\ItemsIndexedEvent;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api_pantheon_cache\EventSubscriber\SolrCommitAwareCacheInvalidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @coversDefaultClass \Drupal\search_api_pantheon_cache\EventSubscriber\SolrCommitAwareCacheInvalidator
+ * @group search_api_pantheon
+ */
+class SolrCommitAwareCacheInvalidatorTest extends TestCase {
+
+  /**
+   * In-memory state storage for testing.
+   *
+   * @var array
+   */
+  protected array $stateStorage = [];
+
+  /**
+   * The mock state service.
+   *
+   * @var \Drupal\Core\State\StateInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $state;
+
+  /**
+   * The invalidator under test.
+   *
+   * @var \Drupal\Tests\search_api_pantheon_cache\Unit\TestableSolrCommitAwareCacheInvalidator
+   */
+  protected TestableSolrCommitAwareCacheInvalidator $invalidator;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->stateStorage = [];
+    $this->state = $this->createMock(StateInterface::class);
+
+    $this->state->method('get')
+      ->willReturnCallback(function (string $key, $default = NULL) {
+        return $this->stateStorage[$key] ?? $default;
+      });
+    $this->state->method('set')
+      ->willReturnCallback(function (string $key, $value) {
+        $this->stateStorage[$key] = $value;
+      });
+    $this->state->method('delete')
+      ->willReturnCallback(function (string $key) {
+        unset($this->stateStorage[$key]);
+      });
+
+    $this->invalidator = new TestableSolrCommitAwareCacheInvalidator($this->state);
+  }
+
+  /**
+   * @covers ::invalidateTags
+   * @covers ::scheduleReInvalidation
+   */
+  public function testSearchApiListTagsScheduleReInvalidation(): void {
+    $this->invalidator->invalidateTags([
+      'node:5',
+      'search_api_list:primary',
+      'node_list',
+    ]);
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayHasKey('search_api_list:primary', $pending);
+    $this->assertArrayNotHasKey('node:5', $pending);
+    $this->assertArrayNotHasKey('node_list', $pending);
+  }
+
+  /**
+   * @covers ::invalidateTags
+   * @covers ::scheduleReInvalidation
+   */
+  public function testNonSearchTagsIgnored(): void {
+    $this->invalidator->invalidateTags([
+      'node:5',
+      'node_list',
+      'config:views.view.search',
+    ]);
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertEmpty($pending);
+  }
+
+  /**
+   * @covers ::onItemsIndexed
+   */
+  public function testItemsIndexedSchedulesReInvalidation(): void {
+    $index = $this->createMock(IndexInterface::class);
+    $index->method('id')->willReturn('primary');
+
+    $event = new ItemsIndexedEvent($index, ['item_1', 'item_2']);
+    $this->invalidator->onItemsIndexed($event);
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayHasKey('search_api_list:primary', $pending);
+  }
+
+  /**
+   * @covers ::scheduleReInvalidation
+   */
+  public function testRapidEditsUpdateTimestamp(): void {
+    $this->invalidator->invalidateTags(['search_api_list:primary']);
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY];
+    $first_timestamp = $pending['search_api_list:primary'];
+
+    $this->invalidator->invalidateTags(['search_api_list:primary']);
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY];
+    $second_timestamp = $pending['search_api_list:primary'];
+
+    $this->assertGreaterThanOrEqual($first_timestamp, $second_timestamp);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestDoesNotFireEarly(): void {
+    $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] = [
+      'search_api_list:primary' => time() + 6,
+    ];
+
+    $this->invalidator->onRequest($this->createRequestEvent());
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayHasKey('search_api_list:primary', $pending);
+    $this->assertEmpty($this->invalidator->reInvalidatedTags);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestFiresWhenDue(): void {
+    $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] = [
+      'search_api_list:primary' => time() - 1,
+    ];
+
+    $this->invalidator->onRequest($this->createRequestEvent());
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayNotHasKey('search_api_list:primary', $pending);
+    $this->assertContains('search_api_list:primary', $this->invalidator->reInvalidatedTags);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestPreservesNotDueEntries(): void {
+    $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] = [
+      'search_api_list:primary' => time() - 1,
+      'search_api_list:secondary' => time() + 60,
+    ];
+
+    $this->invalidator->onRequest($this->createRequestEvent());
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayNotHasKey('search_api_list:primary', $pending);
+    $this->assertArrayHasKey('search_api_list:secondary', $pending);
+    $this->assertContains('search_api_list:primary', $this->invalidator->reInvalidatedTags);
+    $this->assertNotContains('search_api_list:secondary', $this->invalidator->reInvalidatedTags);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testSubRequestIgnored(): void {
+    $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] = [
+      'search_api_list:primary' => time() - 1,
+    ];
+
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    $event = new RequestEvent($kernel, new Request(), HttpKernelInterface::SUB_REQUEST);
+    $this->invalidator->onRequest($event);
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayHasKey('search_api_list:primary', $pending);
+    $this->assertEmpty($this->invalidator->reInvalidatedTags);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOnRequestEmptyStateNoop(): void {
+    $this->invalidator->onRequest($this->createRequestEvent());
+    $this->assertArrayNotHasKey(SolrCommitAwareCacheInvalidator::STATE_KEY, $this->stateStorage);
+    $this->assertEmpty($this->invalidator->reInvalidatedTags);
+  }
+
+  /**
+   * @covers ::getSubscribedEvents
+   */
+  public function testSubscribedEvents(): void {
+    $events = SolrCommitAwareCacheInvalidator::getSubscribedEvents();
+    $this->assertArrayHasKey('search_api.items_indexed', $events);
+    $this->assertArrayHasKey(KernelEvents::REQUEST, $events);
+  }
+
+  /**
+   * @covers ::scheduleReInvalidation
+   */
+  public function testMultipleIndexesIndependent(): void {
+    $this->invalidator->invalidateTags([
+      'search_api_list:primary',
+      'search_api_list:products',
+    ]);
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertArrayHasKey('search_api_list:primary', $pending);
+    $this->assertArrayHasKey('search_api_list:products', $pending);
+    $this->assertCount(2, $pending);
+  }
+
+  /**
+   * @covers ::invalidateTags
+   * @covers ::onRequest
+   */
+  public function testReInvalidationDoesNotReschedule(): void {
+    $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] = [
+      'search_api_list:primary' => time() - 1,
+    ];
+
+    $this->invalidator->onRequest($this->createRequestEvent());
+
+    $pending = $this->stateStorage[SolrCommitAwareCacheInvalidator::STATE_KEY] ?? [];
+    $this->assertEmpty($pending);
+  }
+
+  /**
+   * Creates a main request event for testing.
+   */
+  protected function createRequestEvent(): RequestEvent {
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    return new RequestEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
+  }
+
+}

--- a/modules/search_api_pantheon_cache/tests/src/Unit/TestableSolrCommitAwareCacheInvalidator.php
+++ b/modules/search_api_pantheon_cache/tests/src/Unit/TestableSolrCommitAwareCacheInvalidator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\search_api_pantheon_cache\Unit;
+
+use Drupal\search_api_pantheon_cache\EventSubscriber\SolrCommitAwareCacheInvalidator;
+
+/**
+ * Testable subclass that captures re-invalidation calls.
+ */
+class TestableSolrCommitAwareCacheInvalidator extends SolrCommitAwareCacheInvalidator {
+
+  /**
+   * Tags that were re-invalidated.
+   *
+   * @var array
+   */
+  public array $reInvalidatedTags = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function reInvalidateTags(array $tags): void {
+    $this->reInvalidatedTags = array_merge($this->reInvalidatedTags, $tags);
+  }
+
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,7 @@
   </php>
   <testsuites>
     <testsuite name="unit">
-      <directory phpVersion="8.1.0" phpVersionOperator=">=">./tests/Unit/</directory>
+      <directory phpVersion="8.1.0" phpVersionOperator=">=">./modules/search_api_pantheon_cache/tests/src/Unit/</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Bootstrap file for PHPUnit tests.
+ */
+
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoloader)) {
+  require_once $autoloader;
+
+  // Register contrib module namespaces for standalone unit tests.
+  $vendor = __DIR__ . '/../vendor';
+  $loader = new \Composer\Autoload\ClassLoader();
+  $loader->addPsr4('Drupal\\search_api\\', "$vendor/drupal/search_api/src/");
+  $loader->addPsr4('Drupal\\search_api_solr\\', "$vendor/drupal/search_api_solr/src/");
+  $loader->register();
+}


### PR DESCRIPTION
## Summary

- Adds `search_api_pantheon_cache` submodule that re-invalidates Solr-backed Views cache after `autoSoftCommit` fires (~5s), preventing stale search results
- Module enabled = feature active. No config toggle — zero overhead for sites that don't need it
- Alternative to the config-toggle approach in #282, better for cases where only specific sites (e.g. Content Publisher) need this fix

### How it works

1. When Drupal invalidates `search_api_list:*` cache tags (entity save), the submodule schedules a re-invalidation 6 seconds later via State API
2. On the next uncached request after the delay, `onRequest()` fires the re-invalidation, flushing any stale cached Views that were rendered before Solr committed

### Race condition 

Drupal invalidates cache tags at entity-save time, but Solr's `autoSoftCommit` doesn't make the new document visible for ~5 seconds. Any visitor who hits a Solr-backed View during that window gets stale results cached in Drupal's render cache.

