### PR TITLE
SITE-5791: pin actions to Node 24 release SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           php-version: ${{ env.PHP_VERSION }}
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
+        uses: pantheon-systems/terminus-github-actions@b0a005d0e886678b25cb6cd7833cf8d8cf779900 # v1.2.9
         with:
           pantheon-machine-token: ${{env.TERMINUS_TOKEN}}
           terminus-version: ${{env.TERMINUS_VERSION}}

--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -18,11 +18,11 @@ jobs:
       DRUPAL_ORG_REMOTE: ${{ secrets.DRUPAL_ORG_REMOTE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}


### PR DESCRIPTION
GitHub removes Node.js 20 from the runners on 16 September 2026. Any action still running on Node 20 stops working then. This repo referenced two actions by floating tag in `create-branch-on-tag.yml`, and consumes one SiteX shared action.

| Action | Was | Now | Runtime before |
|---|---|---|---|
| `actions/checkout` | `@v3` | `@3d3c42e` v7.0.1 | node16 |
| `shimataro/ssh-key-action` | `@v2` | `@87a8f06` v2.8.1 | node20 |
| `pantheon-systems/terminus-github-actions` | `@409451e` v1.2.8 | `@b0a005d` v1.2.9 | node20 internally |

The first two are now pinned to the commit SHA of a Node 24 release, with the version as a trailing comment. That covers the two goals of SITE-5791 in one edit: the SHA pin removes the risk of a tag being repointed, and the release bump clears the Node 20 removal.

`terminus-github-actions` needed the composite fixed first, not just pinned. It internally called `actions/cache/restore@v4` and `actions/cache/save@v4`, both on Node 20, so pinning the wrapper here would not have cleared the removal. That was fixed in [terminus-github-actions#48](https://github.com/pantheon-systems/terminus-github-actions/pull/48), which merged and auto-tagged v1.2.9; this PR pins to that release. v1.2.8 to v1.2.9 changed no inputs, so the re-pin carries no contract change.

`create-branch-on-tag.yml` only fires on tag push, so CI here will not exercise it on this PR. It needs a tag push to verify, or a manual check.

Part of SITE-5791 and the CI standardization epic SITE-5778.
