### PR TITLE
docs(readme): [SITE-5661] note duplicated /solr on Lando in troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Diagnostic commands automatically use the first server connected via Pantheon co
 | Search index corruption     | Try reposting schema and reindexing content   |
 | Core reload failures        | Check Solr logs and connection status         |
 | Error after Search API Solr upgrade | Schema incompatibility from 4.2.x → 4.3.x. See [UPGRADE.md](UPGRADE.md#schema-incompatibility-with-search-api-solr-43x) |
+| Duplicated `/solr` in the endpoint URL on Lando | Remove any manual `PANTHEON_INDEX_PATH` override. Since 8.5.0 the connector supplies the Solr context on Lando, so a hand-set `/solr` is added on top of it |
 
 ## Solr Jargon
 


### PR DESCRIPTION
Before 8.5.0 the connector cleared the Solr context on every Pantheon environment, so people set `PANTHEON_INDEX_PATH=/solr` by hand to supply the segment on Lando. Since [PR #263](https://github.com/pantheon-systems/search_api_pantheon/pull/263) the connector supplies it itself, so a kept override produces `//solr/solr/lando/update` and 404s on every index operation.

Nothing in README, UPGRADE.md or the 8.5.0 changelog tells upgraders to remove it. Reported on [drupal.org #3615217](https://www.drupal.org/project/search_api_pantheon/issues/3615217).

Part of SITE-5661.
